### PR TITLE
Support Associate Network ACL

### DIFF
--- a/moto/ec2/responses/network_acls.py
+++ b/moto/ec2/responses/network_acls.py
@@ -96,7 +96,7 @@ DESCRIBE_NETWORK_ACL_RESPONSE = """
    <item>
      <networkAclId>{{ network_acl.id }}</networkAclId>
      <vpcId>{{ network_acl.vpc_id }}</vpcId>
-     <default>true</default>
+     <default>{{ network_acl.default }}</default>
      <entrySet>
        {% for entry in network_acl.network_acl_entries %}
          <item>

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -185,6 +185,14 @@ def network_acl_ids_from_querystring(querystring_dict):
     return network_acl_ids
 
 
+def dhcp_opt_ids_from_querystring(querystring_dict):
+    dhcp_opt_ids = []
+    for key, value in querystring_dict.items():
+        if 'DhcpOptionsId' in key:
+            dhcp_opt_ids.append(value[0])
+    return dhcp_opt_ids
+
+
 def vpc_ids_from_querystring(querystring_dict):
     vpc_ids = []
     for key, value in querystring_dict.items():


### PR DESCRIPTION
add the new_association_id property to
NetworkACL object so that the template
render for replace adds the ID and the
associate_network_acl receives a response
a vpc usually has a default acl
this makes sure that moto flags it
and that the describe response has it in there
