### PR TITLE
Fixing a Invalid Route Id in NetworkACL bug

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -2617,7 +2617,7 @@ class NetworkAclBackend(object):
                             if network_acl.id in network_acl_ids]
             if len(network_acls) != len(network_acl_ids):
                 invalid_id = list(set(network_acl_ids).difference(set([network_acl.id for network_acl in network_acls])))[0]
-                raise InvalidRouteTableIdError(invalid_id)
+                raise InvalidNetworkAclIdError(invalid_id)
 
         return generic_filter(filters, network_acls)
 


### PR DESCRIPTION
describe network acl returns invalid route table id
when no or bad network acl id is given
fixed.
